### PR TITLE
Add jenkinsfile for updating docker image via Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,23 @@
+node('linux') {
+  def image_name = 'statusteam/universal-links-handler'
+  def commit
+  def image
+
+  stage('Git Prep') {
+    checkout scm
+  	commit = sh(returnStdout: true, script: 'git rev-parse --short HEAD').trim()
+  }
+
+  stage('Build') {
+    image = docker.build(image_name + ':' + commit)
+  }
+
+  stage('Publish') {
+    withDockerRegistry([
+			credentialsId: "dockerhub-statusteam-auto", url: ""
+    ]) {
+      image.push()
+      image.push('latest')
+    }
+  }
+}


### PR DESCRIPTION
Simple `Jenkinsfile` for building the image and uploading it to Docker Hub.

Jenkins Build: https://jenkins.status.im/job/tests/job/universal-links-handler/