### PR TITLE
Allow header to wrap so it doesn't fall off screen

### DIFF
--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -92,6 +92,11 @@ h2 {
   text-align: center;
 }
 
+.content h2 {
+  max-width: 100%;
+  word-wrap: break-word;
+}
+
 .content img {
   border-radius: 50%;
   height: 125px;


### PR DESCRIPTION
Fixes #7 

- Add wrapping to the `h2` so it doesn't bleed off screen. It works for all types of links since they all share the same template

What do you all think about this simple solution?

@chadyj @MaxRis @pilu 

# User
![image](https://user-images.githubusercontent.com/27938023/43564514-1518614c-95f5-11e8-9f7c-898e1d9248dc.png)

## Chat
![image](https://user-images.githubusercontent.com/27938023/43564545-29decb3e-95f5-11e8-89db-160748cf4d78.png)

## Browse:
![image](https://user-images.githubusercontent.com/27938023/43564600-73472794-95f5-11e8-902d-57edf4867b64.png)

