### PR TITLE
display QR code for public chat name

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -39,13 +39,18 @@ router.get('/.well-known/apple-app-site-association', function(req, res) {
 
 router.get('/chat/:chatType/:chatId', function(req, res, next) {
   const { chatId, chatType } = req.params;
-  res.render('index', {
-    title: `Join the ${chatType} chat: #${chatId} in Status`,
-    info: `Chat in a public channel <span>#${chatId}</span> in Status.`,
+  chatName = `#${chatId}`;
+  const options = {
+    title: `Join ${chatType} channel #${chatId} on Status`,
+    info: `Join public channel <span>#${chatId}</span> on Status.`,
     path: req.originalUrl,
     chatId: chatId,
-    chatName: chatId,
-  });
+    chatName: chatName,
+  };
+  utils.makeQrCodeDataUri(chatName).then(
+    qrCodeDataUri => res.render('index', { ...options, qrCodeDataUri }),
+    error => res.render('index', options)
+  );
 });
 
 router.get('/user/:userId', function(req, res, next) {


### PR DESCRIPTION
As requested in https://github.com/status-im/universal-links-handler/issues/25 I've implemented displaying the QR code for public chat name. But as I commented on that issue it will not work since App won't know if it's a chat or an ENS name. For that reason I've included the `#` prefix in the QR code so it's not mistaken for an ENS name for now.

Result:
![updated_public_chat_qr](https://user-images.githubusercontent.com/2212681/74369901-7507b180-4dd6-11ea-9242-b1a767330390.png)