### PR TITLE
make button show 'Open in Status' on Android

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -39,13 +39,19 @@ router.get('/.well-known/apple-app-site-association', function(req, res) {
 
 router.get('/chat/:chatType/:chatId', function(req, res, next) {
   const { chatId, chatType } = req.params;
+  /* Make button open chat if on Android */
+  let buttonTitle = 'Download Status'
+  let buttonUrl = 'https://status.im/get/'
+  if (utils.isAndroid(req.headers['user-agent'])) {
+    buttonTitle = 'Open in Status'
+    buttonUrl = `status-im://chat/${chatType}/${chatId}`
+  }
   chatName = `#${chatId}`;
   const options = {
     title: `Join ${chatType} channel #${chatId} on Status`,
     info: `Join public channel <span>#${chatId}</span> on Status.`,
     path: req.originalUrl,
-    chatId: chatId,
-    chatName: chatName,
+    chatId, chatName, buttonTitle, buttonUrl
   };
   utils.makeQrCodeDataUri(chatName).then(
     qrCodeDataUri => res.render('index', { ...options, qrCodeDataUri }),
@@ -55,8 +61,15 @@ router.get('/chat/:chatType/:chatId', function(req, res, next) {
 
 router.get('/user/:userId', function(req, res, next) {
   const { userId } = req.params;
-  chatName = userId
+  /* Make button open user profile if on Android */
+  let buttonTitle = 'Download Status'
+  let buttonUrl = 'https://status.im/get/'
+  if (utils.isAndroid(req.headers['user-agent'])) {
+    buttonTitle = 'Open in Status'
+    buttonUrl = `status-im://user/${userId}`
+  }
   /* chat keys can be resolved to chat names */
+  chatName = userId
   if (utils.isChatKey(userId)) {
     chatName = StatusIm.chatKeyToChatName(userId)
   }
@@ -65,7 +78,7 @@ router.get('/user/:userId', function(req, res, next) {
     info: `Chat and transact with <span>${userId}</span> in Status.`,
     path: req.originalUrl,
     chatId: userId,
-    chatName: chatName,
+    chatName, buttonTitle, buttonUrl
   };
   utils.makeQrCodeDataUri(userId).then(
     qrCodeDataUri => res.render('index', { ...options, qrCodeDataUri }),
@@ -81,6 +94,8 @@ router.get('/extension/:extensionEndpoint', function(req, res, next) {
     path: req.originalUrl,
     chatId: extensionEndpoint,
     chatName: extensionEndpoint,
+    buttonTitle: 'Download Status',
+    buttonUrl: 'https://status.im/get/',
   };
   utils.makeQrCodeDataUri('https://join.status.im/extension/' + extensionEndpoint).then(
     qrCodeDataUri => res.render('index', { ...options, qrCodeDataUri }),

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -173,7 +173,7 @@
                   <div class="inner" id="copy-target"><%= chatId %></div>
                   <a href="#" data-clipboard-target="#copy-target">Copy</a>
                 </div>
-                <a href="https://status.im/get/" class="btn btn-purple-fill">Download Status</a>
+                <a href="<%= buttonUrl %>" class="btn btn-purple-fill"><%= buttonTitle %></a>
                 <div class="info">
                   <%- info %>
                 </div>


### PR DESCRIPTION
This makes the `Download Status` change into `Open in Status` using the `status-im://` URL scheme if the `User-Agent` is an Android phone. This will make the button switch to the given user profile or public chat in the App.

Related: https://github.com/status-im/status-react/issues/10029

Screenshot:
![Screenshot_20200219-181954](https://user-images.githubusercontent.com/2212681/74857814-89066280-5344-11ea-9131-e16a7f757b35.jpg)