### PR TITLE
Redirect uppercase channels

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,11 @@ RUN apk --no-cache add git
 
 RUN mkdir -p /srv
 
-ADD package.json /srv
-ADD yarn.lock /srv
+ADD . /srv
 
 WORKDIR /srv
 
 RUN yarn install
 
-ADD . /srv
-
-CMD yarn start
+CMD yarn run start
 EXPOSE 3000

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "node ./bin/www",
     "watch": "nodemon ./bin/www",
-    "docker": "docker build -t statusteam/universal-links-handler:deploy .",
+    "docker": "yarn run tests && docker build -t statusteam/universal-links-handler:deploy .",
     "tests": "node -r esm tests/main.js"
   },
   "dependencies": {

--- a/routes/index.js
+++ b/routes/index.js
@@ -124,7 +124,7 @@ router.get(/^\/user\/(.+)$/, handleEnsName) /* Legacy */
 
 router.get(/^\/([a-z0-9-]+)$/, handlePublicChannel)
 router.get(/^\/chat\/public\/([a-z0-9-]+)$/, handlePublicChannel) /* Legacy */
-router.get(/^\/([a-zA-Z0-9-]+)$/, handleError('Upper case channel names are invalid'))
+router.get(/^\/([a-zA-Z0-9-]+)$/, (req, res) => res.redirect(req.originalUrl.toLowerCase()))
 
 /* Catchall for everything else */
 router.get('*',  (req, res, next) => {

--- a/tests/main.js
+++ b/tests/main.js
@@ -79,8 +79,8 @@ test('test public channel routes', t => {
 
   t.test('/staTus-TesT - UPPER CASE', async t => { /* we don't allow uppercase */
     const res = await get('/staTus-TesT')
-    t.equal(res.statusCode, 400, 'returns 400')
-    t.ok(res.text.includes('Upper case channel names are invalid'), 'contains error')
+    t.equal(res.statusCode, 302, 'returns 302')
+    t.ok(res.headers['location'], '/status-test', 'redirects to lowercase')
   })
 })
 


### PR DESCRIPTION
Related to [this comment](https://github.com/status-im/status-react/issues/10083#issuecomment-596580328). Instead of showing an error we're redirecting uppercase names of channels to lowercase to avoid confusion for users.
```
 $ curl -s localhost:3000/CHANNEL-NAME
Found. Redirecting to /channel-name
```

Other two commits are small fixes for Docker container build process.