### PR TITLE
implement passing URL args to PlayStore

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,9 +1,10 @@
-var createError = require('http-errors');
-var express = require('express');
-var path = require('path');
-var cookieParser = require('cookie-parser');
+const createError = require('http-errors');
+const express = require('express');
+const morgan = require('morgan')
+const path = require('path');
+const cookieParser = require('cookie-parser');
 
-var indexRouter = require('./routes/index');
+const indexRouter = require('./routes/index');
 
 var app = express();
 
@@ -14,6 +15,7 @@ app.set('view engine', 'ejs');
 // accept the X-Forwarded-* headers
 app.set('trust proxy', true)
 
+app.use(morgan('tiny'))
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());

--- a/app.js
+++ b/app.js
@@ -15,11 +15,14 @@ app.set('view engine', 'ejs');
 // accept the X-Forwarded-* headers
 app.set('trust proxy', true)
 
-app.use(morgan('tiny'))
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
 app.use(express.static(path.join(__dirname, 'public')));
+
+if (process.env.NODE_ENV == 'development') {
+  app.use(morgan('tiny'))
+}
 
 app.use('/', indexRouter);
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "univeil": "^0.1.14"
   },
   "devDependencies": {
+    "cheerio": "^1.0.0-rc.3",
     "esm": "^3.2.25",
     "nodemon": "^1.17.5",
     "supertest": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "scripts": {
     "start": "node ./bin/www",
-    "watch": "nodemon ./bin/www",
+    "watch": "NODE_ENV=development nodemon ./bin/www",
     "docker": "yarn run tests && docker build -t statusteam/universal-links-handler:deploy .",
-    "tests": "node -r esm tests/main.js"
+    "tests": "node -r esm tests/main.js | tap-color"
   },
   "dependencies": {
     "cookie-parser": "~1.4.3",
@@ -24,6 +24,7 @@
     "esm": "^3.2.25",
     "nodemon": "^1.17.5",
     "supertest": "^4.0.2",
+    "tap-color": "^1.2.0",
     "zora": "^3.1.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "express": "~4.16.0",
     "http-errors": "~1.6.2",
     "idna-uts46-hx": "^3.2.2",
-    "js-status-chat-name": "https://github.com/status-im/js-status-chat-name#v0.1.2",
+    "js-status-chat-name": "git+https://github.com/status-im/js-status-chat-name.git#v0.1.2",
+    "morgan": "^1.9.1",
     "qrcode": "^1.3.0",
     "univeil": "^0.1.14"
   },

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1,52 +1,110 @@
-(function() {
-  function buildPlayStoreUrl() {
-    var androidId = $('meta[property="al:android:package"]').attr("content");
-    return "https://play.google.com/store/apps/details?id=" + androidId;
+/* this is to detect if the deep link has worked */
+var siteLostFocus = false;
+document.addEventListener("visibilitychange", (ev) => { siteLostFocus = true; });
+
+/* helper for waiting */
+const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms))
+
+/* helper for checking if site is in focus */
+const isHidden = () => document.visibilityState == 'hidden'
+
+/* parse URL for params and return an object */
+const _getParams = (url) => {
+  let params = {};
+  let parser = document.createElement('a');
+  parser.href = url;
+  let query = parser.search.substring(1);
+  let vars = query.split('&');
+  for (let i = 0; i < vars.length; i++) {
+    let pair = vars[i].split('=');
+    params[pair[0]] = decodeURIComponent(pair[1]);
+  }
+  return params;
+};
+
+/* convert key/values to formatted URL arguments */
+const _formatArgs = (args) => encodeURIComponent(
+  Object.entries(args).map((x) => `${x[0]}=${x[1]}`).join('&')
+)
+
+const _buildPlayStoreUrl = (referrer) => (
+  'https://play.app.goo.gl/?link=' + encodeURIComponent(
+  'https://play.google.com/store/apps/' +
+  `details?id=${_getMetaProp('al:android:package')}` +
+  (typeof referrer == 'undefined' ? '' : `&referrer=${referrer}`))
+)
+
+/* helper for querying meta properties */
+const _getMetaProp = (prop) => $(`meta[property="${prop}"]`).attr("content")
+
+/* helper to detect Android/iOS user agent */
+const _userAgentHas = (str) => navigator.userAgent.toLowerCase().indexOf(str) > -1
+
+/* redirect to Play Store based on URL */
+const getPlayStoreUrl = () => {
+  let params = _getParams(window.location.href)
+  /* action for app to take after installation */
+  let args = { out: _getMetaProp('status-im:target') }
+
+  /* if available set invite and cid arguments */
+  if (params.invite) { args.invite = params.invite }
+  if (params.cid) { args.cid = params.cid }
+
+  return _buildPlayStoreUrl(_formatArgs(args))
+}
+
+const getAppStoreUrl = () => (
+  'https://apps.apple.com/us/app/status-private-communication/id1178893006'
+)
+
+const redirectToStore = () => {
+  /* to avoid showing store after app has been opened */
+  if (siteLostFocus || isHidden()) { return }
+
+  var url
+  if (_userAgentHas('android')) {
+    url = getPlayStoreUrl()
+  } else if (_userAgentHas('iphone')) {
+    url = getAppStoreUrl()
+  } else { /* there's no desktop status app */
+    url = 'https://status.im/'
+  }
+  console.log(`Redirecting to: ${url}`)
+  window.location.replace(url);
+}
+
+/* Open in Status Button --------------------------------------------------*/
+
+const redirectToAppOrStore = () => {
+  if (_userAgentHas('android')) {
+    /* First try to use the Android deep link */
+    window.location.replace(_getMetaProp('al:android:url'));
+  } else if (_userAgentHas('iphone')) {
+    window.location.replace(_getMetaProp('al:ios:url'));
   }
 
-  function buildItunesUrl() {
-    var iosId = $('meta[property="al:ios:app_store_id"]').attr("content");
-    return "https://itunes.apple.com/app/status-ethereum-anywhere/id" + iosId;
-  }
+  /* After a timeout redirect to PlayStore */
+  setTimeout(redirectToStore, 3000);
 
-  function isAndroid(userAgent) {
-    return userAgent.toLowerCase().indexOf("android") > -1;
-  }
+  /* return false to prevent href from taking effect */
+  sleep(500);
+  return !siteLostFocus;
+};
 
-  function isIOS(userAgent) {
-    return userAgent.toLowerCase().indexOf("iphone") > -1;
-  }
+/* Click Button Support ---------------------------------------------------*/
 
-  function testFlightURL() {
-    return "https://testflight.apple.com/join/J8EuJmey";
-  }
+/* disable default action on click */
+$('.copy a').on('click', function(event) {
+  event.preventDefault();
+});
 
-  function webURL() {
-    return "https://status.im/";
-  }
+/* handle all buttons with copy class */
+var clipboard = new ClipboardJS('.copy a');
 
-  $(document).ready(function () {
-    var appStoreLink = $('.app-store-link');
-    if (isAndroid(navigator.userAgent)) {
-      appStoreLink.attr('href', buildPlayStoreUrl());
-    } else if (isIOS(navigator.userAgent)) {
-      appStoreLink.attr('href', testFlightURL());
-    } else {
-      appStoreLink.attr('href', webURL());
-    }
-  });
-
-  $('.copy a').on('click', function(event) {
-    event.preventDefault();
-  });
-
-  var clipboard = new ClipboardJS('.copy a');
-
-  clipboard.on('success', function(e) {
-    $('.copy a').text('Copied');
-    setTimeout(function() {
-      $('.copy a').text('Copy');
-    }, 5000);
-  });
-
-}());
+/* change button text after success */
+clipboard.on('success', function(e) {
+  $('.copy a').text('Copied');
+  setTimeout(function() {
+    $('.copy a').text('Copy');
+  }, 5000);
+});

--- a/public/js/dev.js
+++ b/public/js/dev.js
@@ -113,10 +113,6 @@ $(document).ready(function ($) {
     retrieveAdvocacyPrograms();
   }
 
-  $('.sidebar').stick_in_parent({
-    offset_top: 30
-  });
-
   if ($('input[name="userSearch"]').length) {
     window.addEventListener('click', function (e) {
       if (document.getElementById('search-form').contains(e.target)) {
@@ -308,9 +304,6 @@ $(document).ready(function ($) {
       var id = $(this).attr('id');
       var title = $(this).text();
       $('.right-sub-navigation ul').append('<li class="li-' + $(this)[0].nodeName.toLowerCase() + '"><a href="#' + id + '">' + title + '</a></li>');
-    });
-    $('.right-sub-navigation').stick_in_parent({
-      offset_top: 30
     });
     $('.right-sub-navigation a').on('click', function () {
       var id = $(this).attr('href');

--- a/resources/links.json
+++ b/resources/links.json
@@ -1,5 +1,5 @@
 {
   "getStatus": "https://status.im/get/",
   "playStore": "https://play.google.com/store/apps/details?id=im.status.ethereum",
-  "appleStore": "https://testflight.apple.com/join/J8EuJmey"
+  "appleStore": "https://apps.apple.com/us/app/status-private-communication/id1178893006"
 }

--- a/routes/index.js
+++ b/routes/index.js
@@ -10,14 +10,10 @@ var router = express.Router()
 
 /* Helper for generating pages */
 const genPage = (req, res, options) => {
-  let opts = {
-    ...options,
-    buttonTitle: 'Open in Status',
-    buttonUrl: genUrl(req, options.path),
-  }
-  utils.makeQrCodeDataUri(opts.buttonUrl).then(
-    qrUri => res.render('index', { ...opts, qrUri }),
-    error => res.render('index', opts)
+  let qrUrl = genUrl(req, options.path)
+  utils.makeQrCodeDataUri(qrUrl).then(
+    qrUri => res.render('index', { ...options, qrUri }),
+    error => res.render('index', options)
   )
 }
 
@@ -43,7 +39,7 @@ const handleSite = (req, res) => {
   genPage(req, res, {
     title: `Browse to ${url} in Status`,
     info: `Browse to ${url} in Status`,
-    copyTarget: url,
+    mainTarget: url,
     headerName: `<a href="https://${url}">${url}</a>`,
     path: `/b/${url}`
   })
@@ -63,7 +59,7 @@ const handleChatKey = (req, res) => {
   genPage(req, res, {
     title: `Join ${chatName} in Status`,
     info: `Chat and transact with <span>${chatKey}</span> in Status.`,
-    copyTarget: chatKey,
+    mainTarget: chatKey,
     headerName: chatName,
     path: `/${chatKey}`,
   })
@@ -82,7 +78,7 @@ const handleEnsName = (req, res) => {
   genPage(req, res, {
     title: `Join @${username} in Status`,
     info: `Chat and transact with <span>@${username}</span> in Status.`,
-    copyTarget: username,
+    mainTarget: username,
     headerName: `@${utils.showSpecialChars(username)}`,
     path: req.originalUrl,
   })
@@ -94,8 +90,8 @@ const handlePublicChannel = (req, res) => {
   genPage(req, res, {
     title: `Join #${chatName} in Status`,
     info: `Join public channel <span>#${chatName}</span> on Status.`,
+    mainTarget: chatName, 
     headerName: `#${chatName}`,
-    copyTarget: chatName, 
     path: req.originalUrl,
   })
 }

--- a/tests/main.js
+++ b/tests/main.js
@@ -1,4 +1,5 @@
 import { test } from 'zora'
+import cheerio from 'cheerio'
 import request from 'supertest'
 import app from '../app'
 import links from '../resources/links.json'
@@ -15,111 +16,122 @@ const get = (path) => (
   srv.get(path).set('Host', host)
 )
 
+/* helpers for querying returned HTML */
+const q = (res, query) => cheerio.load(res.text)(query)
+const html = (res, query) => cheerio.load(res.text)(query).html().trim()
+const meta = (res, name) => q(res, `meta[property="${name}"]`).attr('content')
+
 test('test browser routes', t => {
   t.test('/b/ens.domains - VALID', async t => {
     const res = await get('/b/ens.domains')
-    t.equal(res.statusCode, 200, 'returns 200')
-    t.ok(res.text.includes(`href="http://${host}/b/ens.domains"`), 'contains link')
-    t.ok(res.text.includes('Browse to ens.domains in Status'), 'contains text')
+    t.eq(res.statusCode, 200, 'returns 200')
+    t.eq(meta(res, 'status-im:target'), 'ens.domains', 'contains target')
+    t.eq(meta(res, 'al:ios:url'), 'status-im://b/ens.domains', 'contains ios url')
+    t.eq(meta(res, 'al:android:url'), 'status-im://b/ens.domains', 'contains android url')
+    t.eq(html(res, 'div.info'), 'Browse to ens.domains in Status', 'contains prompt')
   })
 })
 
 test('test user ens routes', t => {
   t.test('/@jakubgs.eth - VALID', async t => {
     const res = await get('/@jakubgs.eth')
-    t.equal(res.statusCode, 200, 'returns 200')
-    t.ok(res.text.includes(`href="http://${host}/@jakubgs.eth"`), 'contains link')
-    t.ok(res.text.includes('Chat and transact with <span>@jakubgs.eth</span> in Status.'), 'contains prompt')
+    t.eq(res.statusCode, 200, 'returns 200')
+    t.eq(meta(res, 'al:ios:url'), 'status-im://@jakubgs.eth', 'contains ios url')
+    t.eq(meta(res, 'al:android:url'), 'status-im://@jakubgs.eth', 'contains android url')
+    t.eq(html(res, 'div.info'), 'Chat and transact with <span>@jakubgs.eth</span> in Status.', 'contains prompt')
   })
 
   t.test('/@jAkuBgs.eth.eth - UPPER CASE', async t => { /* we don't allow uppercase */
     const res = await get('/@jAkuBgs.eth')
-    t.equal(res.statusCode, 400, 'returns 400')
-    t.ok(res.text.includes('Upper case ENS names are invalid'), 'contains error')
+    t.eq(res.statusCode, 400, 'returns 400')
+    t.eq(html(res, 'code#error'), 'Upper case ENS names are invalid', 'contains error')
   })
 })
 
 test('test chat key routes', t => {
   t.test(`/0x04${chatKey.substr(0,8)}... - VALID`, async t => {
     const res = await get(`/0x04${chatKey}`)
-    t.equal(res.statusCode, 200, 'returns 200')
-    t.ok(res.text.includes(`href="http://${host}/0x04${chatKey}"`), 'contains link')
-    t.ok(res.text.includes(`Chat and transact with <span>0x04${chatKey}</span> in Status.`), 'contains prompt')
-    t.ok(res.text.includes(chatName), 'contains chat name')
+    t.eq(res.statusCode, 200, 'returns 200')
+    t.eq(meta(res, 'al:ios:url'), `status-im://0x04${chatKey}`, 'contains ios url')
+    t.eq(meta(res, 'al:android:url'), `status-im://0x04${chatKey}`, 'contains android url')
+    t.eq(html(res, 'div.info'), `Chat and transact with <span>0x04${chatKey}</span> in Status.`, 'contains prompt')
+    t.eq(html(res, '#header'), chatName, 'contains chat name')
   })
 
   t.test(`/0x04${chatKey.substr(0,8).toUpperCase()}... - LOWER CASE`, async t => { /* convert upper to lowe case */
     const res = await get(`/0x04${chatKey.toUpperCase()}`)
-    t.equal(res.statusCode, 200, 'returns 200')
-    t.ok(res.text.includes(`href="http://${host}/0x04${chatKey}"`), 'contains link')
-    t.ok(res.text.includes(`Chat and transact with <span>0x04${chatKey}</span> in Status.`), 'contains prompt')
-    t.ok(res.text.includes(chatName), 'contains chat name')
+    t.eq(res.statusCode, 200, 'returns 200')
+    t.eq(meta(res, 'al:ios:url'), `status-im://0x04${chatKey}`, 'contains ios url')
+    t.eq(meta(res, 'al:android:url'), `status-im://0x04${chatKey}`, 'contains android url')
+    t.eq(html(res, 'div.info'), `Chat and transact with <span>0x04${chatKey}</span> in Status.`, 'contains prompt')
+    t.eq(html(res, '#header'), chatName, 'contains chat name')
   })
 
   t.test(`/0x04${chatKey.substr(0,8)}...abc - TOO LONG`, async t => { /* error on too long chat key */
     const res = await get(`/0x04${chatKey}abc`)
-    t.equal(res.statusCode, 400, 'returns 400')
-    t.ok(res.text.includes('Incorrect length of chat key'), 'contains error')
+    t.eq(res.statusCode, 400, 'returns 400')
+    t.eq(html(res, 'code#error'), 'Incorrect length of chat key', 'contains error')
   })
 
   t.test(`/0x04${chatKey.substr(0,8)}... - TOO SHORT`, async t => { /* error on too short chat key */
     const res = await get(`/0x04${chatKey.substr(0,127)}`)
-    t.equal(res.statusCode, 400, 'returns 400')
-    t.ok(res.text.includes('Incorrect length of chat key'), 'contains error')
+    t.eq(res.statusCode, 400, 'returns 400')
+    t.eq(html(res, 'code#error'), 'Incorrect length of chat key', 'contains error')
   })
 })
 
 test('test public channel routes', t => {
   t.test('/status-test - VALID', async t => {
     const res = await get('/status-test')
-    t.equal(res.statusCode, 200, 'returns 200')
-    t.ok(res.text.includes(`href="http://${host}/status-test"`), 'contains link')
-    t.ok(res.text.includes('Join public channel <span>#status-test</span> on Status.'), 'contains prompt')
+    t.eq(res.statusCode, 200, 'returns 200')
+    t.eq(meta(res, 'al:ios:url'), 'status-im://status-test', 'contains ios url')
+    t.eq(meta(res, 'al:android:url'), 'status-im://status-test', 'contains android url')
+    t.eq(html(res, 'div.info'), 'Join public channel <span>#status-test</span> on Status.', 'contains prompt')
   })
 
   t.test('/staTus-TesT - UPPER CASE', async t => { /* we don't allow uppercase */
     const res = await get('/staTus-TesT')
-    t.equal(res.statusCode, 302, 'returns 302')
-    t.ok(res.headers['location'], '/status-test', 'redirects to lowercase')
+    t.eq(res.statusCode, 302, 'returns 302')
+    t.eq(res.headers['location'], '/status-test', 'redirects to lowercase')
   })
 })
 
 test('test other routes', t => {
   t.test('/health', async t => {
     const res = await get('/health')
-    t.equal(res.statusCode, 200, 'returns 200')
-    t.equal(res.text, 'OK', 'returns OK')
+    t.eq(res.statusCode, 200, 'returns 200')
+    t.eq(res.text, 'OK', 'returns OK')
   })
 
   t.test('/.well-known/assetlinks.json', async t => {
     const res = await get('/.well-known/assetlinks.json')
-    t.equal(res.statusCode, 200, 'returns 200')
-    t.equal(res.text, JSON.stringify(assetLinks), 'returns asset links')
+    t.eq(res.statusCode, 200, 'returns 200')
+    t.eq(res.text, JSON.stringify(assetLinks), 'returns asset links')
   })
 
   t.test('/.well-known/apple-app-site-association', async t => {
     const res = await get('/.well-known/apple-app-site-association')
-    t.equal(res.statusCode, 200, 'returns 200')
-    t.equal(res.text, JSON.stringify(appleSiteAssociation), 'returns apple association')
+    t.eq(res.statusCode, 200, 'returns 200')
+    t.eq(res.text, JSON.stringify(appleSiteAssociation), 'returns apple association')
   })
 })
 
 test('catch-all route', t => {
   t.test('redirects to status.im', async t => {
     const res = await get('/')
-    t.equal(res.statusCode, 302, 'returns 302')
-    t.equal(res.headers.location, links.getStatus, 'sets location')
+    t.eq(res.statusCode, 302, 'returns 302')
+    t.eq(res.headers.location, links.getStatus, 'sets location')
   })
 
   t.test('redirects to play store', async t => {
     const res = await get('/').set('user-agent', 'xyz Android xyz')
-    t.equal(res.statusCode, 302, 'returns 302')
-    t.equal(res.headers.location, links.playStore, 'sets location')
+    t.eq(res.statusCode, 302, 'returns 302')
+    t.eq(res.headers.location, links.playStore, 'sets location')
   })
 
   t.test('redirects to apple store', async t => {
     const res = await get('/').set('user-agent', 'xyz iPhone xyz')
-    t.equal(res.statusCode, 302, 'returns 302')
-    t.equal(res.headers.location, links.appleStore, 'sets location')
+    t.eq(res.statusCode, 302, 'returns 302')
+    t.eq(res.headers.location, links.appleStore, 'sets location')
   })
 })

--- a/views/fail.ejs
+++ b/views/fail.ejs
@@ -1,7 +1,7 @@
 <section class="join-error p-b-160 p-t-160 text-center">
-  <h3>Invalid input format</h3>
+  <h3 id="header">Invalid input format</h3>
   <p>
-    Parsing of given URL failed with: <code><%= error.message %></code></br>
+    Parsing of given URL failed with: <code id="error"><%= error.message %></code></br>
     This might be a phishing attack or simply a malformed ENS name.
   </p>
 </section>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -122,12 +122,9 @@
                   </div>
                   <div class="col-md-4 offset-md-1">
                     <ul>
-                      <li><a href="https://status.im/technical/contributor_guide.html" class="link-arrow">Get Started</a></li>
-                      <li><a href="https://status.im/build_status/" class="link-arrow">Build Status</a></li>
-                      <li><a href="https://status.im/nightly/" class="link-arrow">Nightlies</a></li>
-                      <li><a href="https://status.im/developer_tools/" class="link-arrow">Developer Tools</a></li>
-                      <li><a href="https://status.im/research/" class="link-arrow">Research</a></li>
-                      <li><a href="https://status.im/tutorials/" class="link-arrow">Tutorials</a></li>
+                      <li><a href="https://status.im/technical/" class="link-arrow">Contributor Guide</a></li>
+                      <li><a href="https://status.im/developer_tools/" class="link-arrow">DApp Integration</a></li>
+                      <li><a href="https://status.im/our_team/" class="link-arrow">Join Our Team</a></li>
                     </ul>
                   </div>
                 </div>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -9,6 +9,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <% if (locals.path) { %>
+    <meta property="status-im:target" content="<%= mainTarget %>" />
+
     <meta property="al:ios:url" content="status-im:/<%= path %>" />
     <meta property="al:ios:app_store_id" content="1178893006" />
     <meta property="al:ios:app_name" content="Status — Ethereum. Anywhere" />

--- a/views/join.ejs
+++ b/views/join.ejs
@@ -2,21 +2,17 @@
   <div class="container">
     <div class="row">
       <div class="col-md-12">
-        <h3 class="break-word"><%- headerName %></h3>
+        <h3 id="header" class="break-word"><%- headerName %></h3>
         <%if (locals.qrUri) { %>
           <img class="qr-code" src="<%= qrUri %>" />
         <% } %>
         <div class="row">
           <div class="col-md-6 ml-auto mr-auto text-center">
             <div class="copy">
-              <div class="inner" id="copy-target"><%= copyTarget %></div>
+              <div class="inner" id="copy-target"><%= mainTarget %></div>
               <a href="#" data-clipboard-target="#copy-target">Copy</a>
             </div>
-            <%if (locals.buttonUrl) { %>
-            <a href="<%= buttonUrl %>" class="btn btn-purple-fill"><%= buttonTitle %></a>
-            <% } else { %>
-            <a href="https://status.im/get/" class="btn btn-purple-fill">Download Status</a>
-            <% } %>
+            <button href="status-im:/<%= path %>" onclick="return redirectToAppOrStore();" class="btn btn-purple-fill">Open in Status</button>
             <div class="info">
               <%- info %>
             </div>


### PR DESCRIPTION
Changes:

* Makes the `Open in Status` button trigger `redirectToAppOrStore()` JS method on click
* `redirectToAppOrStore()` redirects to a `status-im://` deep link and Play/App store after 500ms
* The redirect to Play Store includes the `referrer` URL argument with additional arguments
* The additional arguments include `out`, `invite`, and `cid`, necessary for [starter packs](https://github.com/status-im/starterpack-service)
* Adds [morgan](https://github.com/expressjs/morgan) for logging of Express requests

Resolves #31