### PR TITLE
fix public key styling by truncating

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -85,7 +85,7 @@ const handleChatKey = (req, res) => {
   }
   genPage(req, res, {
     title: `Join ${chatName} in Status`,
-    info: `Chat and transact with <span>${chatKey}</span> in Status.`,
+    info: `Chat and transact with <span class="inline-block align-bottom w-32 truncate">${chatKey}</span> in Status.`,
     mainTarget: chatKey,
     headerName: chatName,
     path: `/u/${chatKey}`,
@@ -104,7 +104,7 @@ const handleEnsName = (req, res) => {
   }
   genPage(req, res, {
     title: `Join @${username} in Status`,
-    info: `Chat and transact with <span>@${username}</span> in Status.`,
+    info: `Chat and transact with <span class="inline-block align-bottom w-32 truncate">@${username}</span> in Status.`,
     mainTarget: username,
     headerName: `@${utils.showSpecialChars(username)}`,
     path: req.originalUrl,
@@ -116,7 +116,7 @@ const handlePublicChannel = (req, res) => {
   const chatName = req.params[0]
   genPage(req, res, {
     title: `Join #${chatName} in Status`,
-    info: `Join public channel <span>#${chatName}</span> on Status.`,
+    info: `Join public channel <span class="inline-block align-bottom w-32 truncate">#${chatName}</span> on Status.`,
     mainTarget: chatName, 
     headerName: `#${chatName}`,
     path: req.originalUrl,

--- a/views/fail.ejs
+++ b/views/fail.ejs
@@ -4,6 +4,6 @@
     <h3 id="header" class="py-8 break-word text-center font-display font-bold text-2xl">Invalid input format</h3>
     <p class="text-center">Parsing of given URL failed with: <code id="error" class="font-bold"><%= error.message %></code></p>
     </br>
-    <p if="info" class="text-lg text-center">This might be a phishing attack or simply a malformed ENS name.</p>
+    <p if="info" class="pt-4 text-lg text-gray-500 mt-4 text-center">This might be a phishing attack or simply a malformed ENS name.</p>
   </div>
 </section>

--- a/views/join.ejs
+++ b/views/join.ejs
@@ -6,11 +6,11 @@
     <img class="border border-solid border-gray-100 rounded-sm mt-8" src="<%= qrUri %>" />
     <% } %>
     <div class="copy border border-solid border-gray-100 rounded-sm flex items-center justify-between p-6 my-4 h-20">
-      <div class="inner" id="copy-target"><%= mainTarget %></div>
+      <div id="copy-target" class="w-3/4 inner truncate"><%= mainTarget %></div>
       <a href="#" data-clipboard-target="#copy-target" class="text-primary-base font-bold hover:text-primary-700">Copy</a>
     </div>
     <a href="status-im:/<%= path %>" id="open" onclick="return redirectToAppOrStore();" class="font-special font-semibold text-center transition-all duration-200 ease-linear text-white bg-primary-base hover:bg-primary-700 py-5 px-8 block w-full rounded">Open in Status</a>
-    <div id="info" class="text-gray-500 mt-4 text-center">
+    <div id="info" class="pt-4 text-lg text-gray-500 mt-4 text-center">
       <%- info %>
     </div>
   </div>

--- a/views/redirect.ejs
+++ b/views/redirect.ejs
@@ -12,7 +12,7 @@
       <a href="#" data-clipboard-target="#copy-target" class="text-primary-base font-bold hover:text-primary-700">Copy</a>
     </div>
     <a href="<%= redirect.path %>" id="redirect" class="font-special font-semibold text-center transition-all duration-200 ease-linear text-white bg-primary-base hover:bg-primary-700 py-5 px-8 block w-full rounded">Redirect Me</a>
-    <div id="info" class="text-gray-500 mt-4 text-center">
+    <div id="info" class="pt-4 text-lg text-gray-500 mt-4 text-center">
       Beware of phishing attacks.
     </div>
   </div>


### PR DESCRIPTION
When I converted styling from CSS to Tailwind I missed that public keys are not being truncated properly:
|Broken|Fixed|
|-|-|
|![join_pubkey_overflow](https://user-images.githubusercontent.com/2212681/88535734-c4e7d700-d00a-11ea-92b4-50047fca71a5.png)|![join_pubkey_overflow_fixed](https://user-images.githubusercontent.com/2212681/88535816-ec3ea400-d00a-11ea-9bac-932cfcd92660.png)|