### PR TITLE
Add private groups

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,7 @@ WORKDIR /srv
 
 RUN yarn install
 
+ENV NODE_ENV=production
+
 CMD yarn run start
 EXPOSE 3000

--- a/routes/index.js
+++ b/routes/index.js
@@ -23,11 +23,18 @@ const genPage = (req, res, options) => {
 }
 
 /* Helper for full URLs, can specify optional path */
-const genUrl = (req, path) => (
+const genUrl = (req, path) => {
   /* Make button open user profile if on Android */
-  utils.isAndroid(req) ? `status-im:/${path}` :
-    `${req.protocol}://${req.hostname}${path}`
-)
+  if (utils.isAndroid(req)) {
+    return `status-im:/${path}`
+  }
+  /* QR code doesn't work if localhost is used */
+  if (process.env.NODE_ENV == 'development') {
+    return `https://join.status.im${path}`
+  }
+  /* Otherwise just use current server endpoint */
+  return `${req.protocol}://${req.hostname}${path}`
+}
 
 /* Helper for returning syntax errors */
 const handleError = (msg) => (

--- a/utils/index.js
+++ b/utils/index.js
@@ -18,12 +18,13 @@ const makeQrCodeDataUri = (x) => (
   QRCode.toDataURL(x, {width: 300})
 )
 
-const isValidUrl = (text) => {
+const isValidUrl = (text, useStd3ASCII=true) => {
   /* Remove protocol prefix */
   noPrefix = text.replace(/(^\w+:|^)\/\//, '');
   tokens = noPrefix.split('/')
   try {
-    uts46.toUnicode(tokens[0], {useStd3ASCII: true})
+    /* useStd3ASCII=true accepts only DNS domain complaint urls */
+    uts46.toUnicode(tokens[0], {useStd3ASCII})
   } catch(ex) {
     return false
   }

--- a/views/header.ejs
+++ b/views/header.ejs
@@ -192,7 +192,7 @@
         <div class="bg-white relative rounded shadow-lg p-8 xl:p-0 xl:hidden xl:bg-transparent xl:shadow-none">
             <div class="overflow-auto xl:overflow-visible js-mobile-nav-inner">
                 <div class="flex items-center justify-between mb-8">
-                    <a href="/" class="w-32 logo"><img src="img/logo.svg"></a>
+                    <a href="/" class="w-32 logo"><img src="/img/logo.svg"></a>
                     <a href="#" class="js-mobile-nav-trigger-close">
                         <svg width="18" height="17" viewBox="0 0 18 17" fill="none" xmlns="http://www.w3.org/2000/svg"> <rect x="1.5752" y="0.368273" width="22" height="1" rx="0.5" transform="rotate(45 1.5752 0.368273)" fill="#090909"/> <rect x="0.868164" y="15.9246" width="22" height="1" rx="0.5" transform="rotate(-45 0.868164 15.9246)" fill="#090909"/> </svg>
                     </a>


### PR DESCRIPTION
This adds support for Private Group invite URLs.

The code checks for:
- Presence of all three URL arguments: `a`, `a1`, `a2`
- Verifies that `a`(admin key...) is 132 characters long
- Verifies that `a2`(chat key...) is 169 characters long
- Verifies that `a1` does not contain HTML before rendering

Each case is tested, including the valid one.

Resolves: #49