### PR TITLE
Fix qr code invite

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -94,7 +94,7 @@ const handleChatKey = (req, res) => {
     info: `Chat and transact with <span class="inline-block align-bottom w-32 truncate">${chatKey}</span> in Status.`,
     mainTarget: chatKey,
     headerName: chatName,
-    path: `/u/${chatKey}`,
+    path: req.originalUrl,
   })
 }
 

--- a/routes/index.js
+++ b/routes/index.js
@@ -44,7 +44,11 @@ const handleError = (msg) => (
   }
 )
 
-/* Helper for redirecting to upper case URLs */
+/* Helper for redirecting to lower case URL */
+const quickRedirect = (req, res) =>
+  res.redirect(302, req.originalUrl.toLowerCase())
+
+/* Helper for showing a redirect page to lower case URL */
 const handleRedirect = (req, res) => {
   /* Protection against XSS attacks */
   if (!utils.isValidUrl(req.originalUrl)) {
@@ -178,13 +182,17 @@ router.get('/browse/:url(*)', handleSite) /* Legacy */
 
 router.get(/^\/u\/(z[0-9a-zA-Z]{46,49})$/, handleChatKey)
 router.get(/^\/u\/(z[0-9a-zA-Z]+)$/, handleError('Incorrect length of chat key'))
-router.get(/^\/u\/(fe701[0-9a-fA-F]{66})$/, handleChatKey)
+router.get(/^\/u\/(fe701[0-9a-f]{66})$/, handleChatKey)
+router.get(/^\/u\/(fe701[0-9a-fA-F]{66})$/, quickRedirect)
 router.get(/^\/u\/(fe701[0-9a-fA-F]+)$/, handleError('Incorrect length of chat key'))
-router.get(/^\/u\/(f[0-9a-fA-F]{66})$/, handleChatKey)
+router.get(/^\/u\/(f[0-9a-f]{66})$/, handleChatKey)
+router.get(/^\/u\/(f[0-9a-fA-F]{66})$/, quickRedirect)
 router.get(/^\/u\/(f[0-9a-fA-F]+)$/, handleError('Incorrect length of chat key'))
-router.get(/^\/u\/(0[xX]04[0-9a-fA-F]{128})$/, handleChatKey)
+router.get(/^\/u\/(0[xX]04[0-9a-f]{128})$/, handleChatKey)
+router.get(/^\/u\/(0[xX]04[0-9a-fA-F]{128})$/, quickRedirect)
 router.get(/^\/u\/(0[xX]04[0-9a-fA-F]+)$/, handleError('Incorrect length of chat key'))
-router.get(/^\/user\/(0[xX]04[0-9a-fA-F]{128})$/, handleChatKey) /* Legacy */
+router.get(/^\/user\/(0[xX]04[0-9a-f]{128})$/, handleChatKey) /* Legacy */
+router.get(/^\/user\/(0[xX]04[0-9a-fA-F]{128})$/, quickRedirect) /* Legacy */
 
 router.get(/^\/u\/([^><]*[A-Z]+[^><]*)$/, handleRedirect)
 router.get(/^\/u\/([^<>]+)$/, handleEnsName)

--- a/tests/main.js
+++ b/tests/main.js
@@ -79,13 +79,10 @@ test('test chat key routes', t => {
     t.eq(html(res, '#header'), chatName, 'contains chat name')
   })
 
-  t.test(`/u/0x04${chatKey.substr(0,8).toUpperCase()}... - LOWER CASE`, async t => { /* convert upper to lowe case */
+  t.test(`/u/0x04${chatKey.substr(0,8).toUpperCase()}... - UPPER CASE`, async t => { /* redirect to lower case */
     const res = await get(`/u/0x04${chatKey.toUpperCase()}`)
-    t.eq(res.statusCode, 200, 'returns 200')
-    t.eq(meta(res, 'al:ios:url'), `status-im://u/0x04${chatKey}`, 'contains ios url')
-    t.eq(meta(res, 'al:android:url'), `status-im://u/0x04${chatKey}`, 'contains android url')
-    t.eq(html(res, 'div#info'), `Chat and transact with <span class=\"inline-block align-bottom w-32 truncate\">0x04${chatKey}</span> in Status.`, 'contains prompt')
-    t.eq(html(res, '#header'), chatName, 'contains chat name')
+    t.eq(res.statusCode, 302, 'returns 302')
+    t.eq(res.headers.location, `/u/0x04${chatKey}`, 'sets location')
   })
 
   t.test(`/u/0x04${chatKey.substr(0,8)}...abc - TOO LONG`, async t => { /* error on too long chat key */


### PR DESCRIPTION
Changes:

- 21f82a1 - Fixes invite URL argument not showing up in QR code for chat key(`/u/0x04...`) url
- 315bb2f - Adds `302` HTTP redirect from upper case chat key to lower case

Resolves: #50